### PR TITLE
Securely Store Passwords

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -172,6 +172,11 @@
         }
       }
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "express": "^4.16.4",
     "mongodb": "^3.6.1",
     "mongoose": "^5.10.4",

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const { isEmail } = require('validator');
-
-const User = mongoose.model('User', {
+const bcrypt = require('bcryptjs');
+const userSchema = new mongoose.Schema({
   name: {
     type: String,
     required: true,
@@ -38,5 +38,17 @@ const User = mongoose.model('User', {
     }
   }
 });
+
+userSchema.pre('save', async function (next) {
+  const user = this;
+
+  if (user.isModified('password')) {
+    user.password = await bcrypt.hash(user.password, 8);
+  }
+  
+  next();
+});
+
+const User = mongoose.model('User', userSchema);
 
 module.exports = User;

--- a/src/routers/user.js
+++ b/src/routers/user.js
@@ -43,7 +43,9 @@ router.patch('/users/:id', async(req, res) => {
   }
 
   try {
-    const user = await User.findByIdAndUpdate(req.params.id, req.body, { new: true, runValidators: true })
+    const user = await User.findById(req.params.id);
+    updates.forEach((update) => user[update] = req.body[update]);
+    await user.save();
 
     if (!user) {
       return res.status(404).send();


### PR DESCRIPTION
Uses the bcrypt library and express middleware to store hashed passwords
in the db instead of plain text passwords.

Both the create and update routes for the user resource now use
the middleware.